### PR TITLE
Use engine provided by flask sqlalchemy

### DIFF
--- a/flask_restplus_data/FlaskDataRepository.py
+++ b/flask_restplus_data/FlaskDataRepository.py
@@ -60,7 +60,7 @@ def create_new_sql_repo_class(repo_class: type):
             self.primary_keys = primary_keys
 
         def __enter__(self):
-            self.session = orm.sessionmaker(create_engine(self.model_class.url))()
+            self.session = orm.sessionmaker(self.model_class.db.engine)()
             return self
 
         def __exit__(self, exc_type, exc_val, exc_tb):

--- a/flask_restplus_data/database.py
+++ b/flask_restplus_data/database.py
@@ -123,6 +123,7 @@ class FlaskData(Database):
             app.config['MONGOALCHEMY_CONNECTION_STRING'] = self.url
             db = MongoAlchemy(app)
             setattr(self, 'Model', db.Document)
+        setattr(self.Model, 'db', db)
         setattr(self.Model, 'url', self.url)
         setattr(self.Model, 'db_type', self.type)
         return db

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ this_directory = path.abspath(path.dirname(__file__))
 with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
-version = '0.0.7'
+version = '0.0.8'
 author = 'nucklehead'
 github_url = f'https://github.com/{author}/flask-restplus-data'
 
@@ -38,7 +38,7 @@ setup(name='flask_restplus_data',
       packages=find_packages(exclude=['test']),
       install_requires=[
           'confuse==1.0.0',
-          'psycopg2-binary==2.7.7',
+          'psycopg2-binary==2.8.6',
           'flask-sqlalchemy==2.4.1',
           'Flask-MongoAlchemy==0.7.2',
           'yoyo-migrations==6.1.0',


### PR DESCRIPTION
- Use engine provided by flask sqlalchemy
- Updated psycopg2-binary dependency

closes #1 